### PR TITLE
Include project name in wfs3 url

### DIFF
--- a/conf/qgis-server-nginx.conf
+++ b/conf/qgis-server-nginx.conf
@@ -85,7 +85,7 @@ http {
             rewrite ^/ows/$ /qgis/qgis_mapserv.fcgi;
         }
         location /wfs3/ {
-            rewrite ^/wfs3/(.*)$ /qgis/qgis_mapserv.fcgi;
+            rewrite ^/wfs3/([^/]*)/(.*)$ /qgis/qgis_mapserv.fcgi/wfs3/$2?map=/io/data/$1/$1.qgs;
         }
         location /qgis/ {
             internal; # Used only by the OGC rewrite


### PR DESCRIPTION
To deal with multiple projects it would make sense to include the project name in the url. Yet this does not seem to work nicely with the Webinterface links which we do not need currently. So improvements welcome.